### PR TITLE
make saxophone modulatable and try to simplify the code

### DIFF
--- a/src/Saxophone.scd
+++ b/src/Saxophone.scd
@@ -53,10 +53,21 @@ Ndef(\saxophone, \saxophone);
 Ndef(\saxophone).set(\tm, 600);
 Ndef(\saxophone, \saxophone).play(vol:0.1);
 
-Ndef(\saxophone).set(\omega, [1.195,2.483,3.727,4.405,5.153,6.177,6.749,7.987] + 1);
-Ndef(\saxophone).set(\alpha, [0.0176,0.0355,0.0653,0.2693,0.0703,0.166,0.0945,0.1165] + 0.04);
-Ndef(\saxophone).set(\alpha, [0.0176,0.0355,0.0653,0.2693,0.0703,0.166,0.0945,0.1165].scramble);
-Ndef(\saxophone).set(\c, [0.1761,0.4705,0.6494,0.328,0.541,0.2249,0.3822,0.4099].scramble);
+Ndef(\saxophone).set(\omega,  [1.195, 2.483, 3.727, 4.405, 5.153, 6.177, 6.749, 7.987] + 1);
+Ndef(\saxophone).set(\alpha,  [0.0176, 0.0355, 0.0653, 0.2693, 0.0703, 0.166, 0.0945, 0.1165] + 0.04);
+
+Ndef(\saxophone).set(\alpha,  [0.0176, 0.0355, 0.0653, 0.2693, 0.0703, 0.166, 0.0945, 0.1165].scramble); // some random variations
+Ndef(\saxophone).set(\c,  [0.1761, 0.4705, 0.6494, 0.328, 0.541, 0.2249, 0.3822,0.4099].scramble); // some random variations
+
+
+
+// // back to default
+(
+Ndef(\saxophone).set(\omega, [1.195, 2.483, 3.727, 4.405, 5.153, 6.177, 6.749, 7.987]);
+Ndef(\saxophone).set(\alpha, [0.0176, 0.0355, 0.0653, 0.2693, 0.0703, 0.166, 0.0945, 0.1165]);
+Ndef(\saxophone).set(\c, [0.1761, 0.4705, 0.6494, 0.328, 0.541, 0.2249, 0.3822,0.4099]);
+)
+
 
 (
 ~scope = Ndef(\saxophone).scope;
@@ -65,8 +76,9 @@ Ndef(\saxophone).gui;
 )
 
 
+// play with cursor
 
-Ndef(\gamma, { MouseX.kr(0, 0.8) });
-Ndef(\zeta, { MouseY.kr(0, 1) });
+Ndef(\gamma,  { MouseX.kr(0, 0.8).poll(3, "gamma") });
+Ndef(\zeta, { MouseY.kr(0, 1).poll(3, "zeta") });
 Ndef(\saxophone).set(\zeta, Ndef(\zeta), \gamma, Ndef(\gamma));
 

--- a/src/Saxophone.scd
+++ b/src/Saxophone.scd
@@ -1,4 +1,4 @@
-s.options.blockSize = 16;
+s.options.blockSize = 8;
 s.reboot;
 
 ///////////////////////////////////////////////////
@@ -6,32 +6,28 @@ s.reboot;
 (
 Fb1_ODEdef(\saxophone, { |t, y, gamma, zeta| // blow, lip pressue
 	var omega0 = 4.224;
-	var omega = [1.195,2.483,3.727,4.405,5.153,6.177,6.749,7.987];
-	var alpha = [0.0176,0.0355,0.0653,0.2693,0.0703,0.166,0.0945,0.1165];
-	var c = [0.1761,0.4705,0.6494,0.328,0.541,0.2249,0.3822,0.4099];
+	var omega = \omega.kr([1.195, 2.483, 3.727, 4.405, 5.153, 6.177, 6.749, 7.987]);
+	var alpha = \alpha.kr([0.0176, 0.0355, 0.0653, 0.2693, 0.0703, 0.166, 0.0945, 0.1165]);
+	var c = \c.kr([0.1761, 0.4705, 0.6494, 0.328, 0.541, 0.2249, 0.3822, 0.4099]);
 	var pressures = y[2,4..];
 	var velocities = y[3,5..];
 	var equations, u;
+	var pressure = pressures.sum;
+	var fluxVelocity = zeta * max(y[0]+1, 0) * sign(gamma - pressure) * (gamma - pressure).abs.sqrt;
 
-    equations = [
+	equations = [
 		{ y[1] },
 		{
-			var pressure = pressures.sum;
 			var contactForce = 100 * min(y[0]+1, 0).squared * (1-y[1]);
 			var forces = omega0.squared * (contactForce + pressure - gamma - y[0]);
 			var dissipativeForce = omega0.neg * y[1];
 			dissipativeForce + forces
-		},
-    ];
-
-	u = { // velocity of air flux
-		var pressure = pressures.sum;
-		zeta * max(y[0]+1, 0) * sign(gamma - pressure) * (gamma - pressure).abs.sqrt
-	};
+		}
+	];
 
 	8.do { |i|
 		equations = equations.add({
-			(neg(alpha[i]) * pressures[i]) - (2 * omega[i] * velocities[i]) + (2 * c[i] * u.value)
+			(neg(alpha[i]) * pressures[i]) - (2 * omega[i] * velocities[i]) + (2 * c[i] * fluxVelocity)
 		});
 		equations = equations.add({
 			(neg(alpha[i]) * velocities[i]) + (0.5 * omega[i] * pressures[i])
@@ -40,7 +36,7 @@ Fb1_ODEdef(\saxophone, { |t, y, gamma, zeta| // blow, lip pressue
 
 	equations
 
-	}, 0, [-0.3, 0] ++ [0, 0.01].dup(8).flat, 1, 1);
+}, 0, [-0.3, 0] ++ [0, 0.01].dup(8).flat, 1, 1);
 
 SynthDef(\saxophone, {
 	var env = EnvGate.new;
@@ -54,10 +50,23 @@ SynthDef(\saxophone, {
 Ndef(\saxophone, \saxophone);
 )
 
-Ndef(\saxophone, \saxophone).play;
+Ndef(\saxophone).set(\tm, 600);
+Ndef(\saxophone, \saxophone).play(vol:0.1);
+
+Ndef(\saxophone).set(\omega, [1.195,2.483,3.727,4.405,5.153,6.177,6.749,7.987] + 1);
+Ndef(\saxophone).set(\alpha, [0.0176,0.0355,0.0653,0.2693,0.0703,0.166,0.0945,0.1165] + 0.04);
+Ndef(\saxophone).set(\alpha, [0.0176,0.0355,0.0653,0.2693,0.0703,0.166,0.0945,0.1165].scramble);
+Ndef(\saxophone).set(\c, [0.1761,0.4705,0.6494,0.328,0.541,0.2249,0.3822,0.4099].scramble);
 
 (
 ~scope = Ndef(\saxophone).scope;
 ~scope.style = 2;
 Ndef(\saxophone).gui;
 )
+
+
+
+Ndef(\gamma, { MouseX.kr(0, 0.8) });
+Ndef(\zeta, { MouseY.kr(0, 1) });
+Ndef(\saxophone).set(\zeta, Ndef(\zeta), \gamma, Ndef(\gamma));
+

--- a/src/Saxophone.scd
+++ b/src/Saxophone.scd
@@ -1,4 +1,4 @@
-s.options.blockSize = 8;
+s.options.blockSize = 16;
 s.reboot;
 
 ///////////////////////////////////////////////////
@@ -59,6 +59,14 @@ Ndef(\saxophone).set(\alpha,  [0.0176, 0.0355, 0.0653, 0.2693, 0.0703, 0.166, 0.
 Ndef(\saxophone).set(\alpha,  [0.0176, 0.0355, 0.0653, 0.2693, 0.0703, 0.166, 0.0945, 0.1165].scramble); // some random variations
 Ndef(\saxophone).set(\c,  [0.1761, 0.4705, 0.6494, 0.328, 0.541, 0.2249, 0.3822,0.4099].scramble); // some random variations
 
+
+// rough modulations
+Ndef(\omegaN, { [1.195, 2.483, 3.727, 4.405, 5.153, 6.177, 6.749, 7.987] + LFNoise0.kr(1).exprange(0.001, 2) });
+Ndef(\saxophone).set(\omega, Ndef(\omegaN));
+
+// alpha envelopes
+
+Ndef(\gamma,  { MouseX.kr(0, 0.8) + LFNoise1.kr(SinOsc.kr(0.1).range(1, 9), 1).max(0) });
 
 
 // // back to default


### PR DESCRIPTION
… to make it somewhat faster

Please test if this really works as expected. To me it seems so.

This will allow you to modulate with more precision
```
Ndef(\gamma, { MouseX.kr(0, 0.8).poll(3, "gamma") });
Ndef(\zeta, { MouseY.kr(0, 1).poll(3, "zeta") });
Ndef(\saxophone).set(\zeta, Ndef(\zeta), \gamma, Ndef(\gamma));
```